### PR TITLE
Fix zsh completion

### DIFF
--- a/contrib/completion/_voxctl
+++ b/contrib/completion/_voxctl
@@ -1,10 +1,4 @@
-_voxctl_args() {
-  case "${words[1]}" in
-    (playUrl|addUrl)
-      _arguments '*:URL:_urls'
-      ;;
-  esac
-}
+#compdef voxctl
 
 _voxctl() {
   local -a commands
@@ -40,9 +34,17 @@ _voxctl() {
       _describe -t commands 'command' commands
       ;;
     (args)
-      _voxctl_args
+      __voxctl_args
       ;;
   esac
 }
 
-compdef _voxctl voxctl
+__voxctl_args() {
+  case "${words[1]}" in
+    (playUrl|addUrl)
+      _arguments '*:URL:_urls'
+      ;;
+  esac
+}
+
+_voxctl "$@"


### PR DESCRIPTION
This addresses completion issues mentioned here: https://github.com/majjoha/voxctl/pull/1#issuecomment-670546682
Additionally, I moved the actual file from `share/zsh/site-functions` to `contrib/completion` which seems a bit more standard-ish in comparison to other brew distributed stuff.