### PR TITLE
Degrade gracefully if VOX is missing

### DIFF
--- a/voxctl
+++ b/voxctl
@@ -1,6 +1,4 @@
 #!/usr/bin/env osascript -l JavaScript
-const vox = Application("Vox")
-vox.includeStandardAdditions = true
 
 const HELP = `CLI for controlling the VOX music player
 
@@ -12,7 +10,7 @@ Commands:
   quit                # Quits VOX
   play                # Begins playback
   pause               # Pauses playback
-  togglePlay          # Toggles playback between playing and paused 
+  togglePlay          # Toggles playback between playing and paused
   next                # Skips to the next track in the playlist
   previous            # Skips to the previous track in the playlist
   shuffle             # Toggles shuffle on or off
@@ -30,26 +28,25 @@ Commands:
   help                # Prints this information`
 
 const COMMANDS = {
-  start: _ => vox.activate(),
-  quit: _ => vox.quit(),
-  play: _ => vox.play(),
-  pause: _ => vox.pause(),
-  togglePlay: _ => vox.playpause(),
-  next: _ => vox.next(),
-  previous: _ => vox.previous(),
-  shuffle: _ => vox.shuffle(),
-  playUrl: ([_, path]) => vox.playurl(path),
-  addUrl: ([_, path]) => vox.addurl(path),
-  rewindForward: _ => vox.rewindforward(),
-  rewindForwardFast: _ => vox.rewindforwardfast(),
-  rewindBackward: _ => vox.rewindbackward(),
-  rewindBackwardFast: _ => vox.rewindbackwardfast(),
-  increaseVolume: _ => vox.increasvolume(),
-  decreaseVolume: _ => vox.decreasevolume(),
-  togglePlaylist: _ => vox.showhideplaylist(),
-  info: _ => JSON.stringify(currentState(), null, 2),
-  isRunning: _ => vox.running(),
-  help: _ => HELP
+  start: vox => vox.activate(),
+  quit: vox => vox.quit(),
+  play: vox => vox.play(),
+  pause: vox => vox.pause(),
+  togglePlay: vox => vox.playpause(),
+  next: vox => vox.next(),
+  previous: vox => vox.previous(),
+  shuffle: vox => vox.shuffle(),
+  playUrl: (vox, [path]) => vox.playurl(path),
+  addUrl: (vox, [path]) => vox.addurl(path),
+  rewindForward: vox => vox.rewindforward(),
+  rewindForwardFast: vox => vox.rewindforwardfast(),
+  rewindBackward: vox => vox.rewindbackward(),
+  rewindBackwardFast: vox => vox.rewindbackwardfast(),
+  increaseVolume: vox => vox.increasvolume(),
+  decreaseVolume: vox => vox.decreasevolume(),
+  togglePlaylist: vox => vox.showhideplaylist(),
+  info: vox => JSON.stringify(currentState(), null, 2),
+  isRunning: vox => vox.running(),
 }
 
 const currentState = () => ({
@@ -63,12 +60,15 @@ const currentState = () => ({
   volume: vox.playerVolume(),
   uniqueID: vox.uniqueID(),
   playerState: vox.playerState(),
-  repeatState: vox.repeatState()
+  repeatState: vox.repeatState(),
 })
 
 function run(argv) {
   const command = COMMANDS[argv[0]]
-  return command ? command(argv) : COMMANDS.help([])
+  if (!command) return HELP
+  const vox = Application("Vox")
+  vox.includeStandardAdditions = true
+  return command(vox, argv.slice(1))
 }
 
 // vim: ft=javascript


### PR DESCRIPTION
Query macOS for `VOX.app` as late as possible enabling usage to be printed even if VOX isn't installed.